### PR TITLE
Remove 'is_valid' flag from reduction params

### DIFF
--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -153,7 +153,6 @@ void IcfBuilder<T>::UpdateModel(
   // Set joint locking params.
   const JointLockingCacheData<T>& locking =
       MultibodyPlantIcfAttorney<T>::EvalJointLocking(plant_, context);
-  params->reduction.is_valid = true;
   params->reduction.is_smaller = !locking.locked_velocity_indices.empty();
   params->reduction.unlocked_dofs = locking.unlocked_velocity_indices;
   for (int t = 0; t < forest.num_trees(); ++t) {

--- a/multibody/contact_solvers/icf/icf_model.cc
+++ b/multibody/contact_solvers/icf/icf_model.cc
@@ -346,7 +346,6 @@ void IcfModel<T>::ReduceInto(IcfModel<T>* reduced_model,
                              ReducedMapping* mapping) const {
   DRAKE_DEMAND(reduced_model != nullptr);
   DRAKE_DEMAND(mapping != nullptr);
-  DRAKE_DEMAND(params().reduction.is_valid == true);
   // TODO(#23764): implement.
   DRAKE_DEMAND(false);
 }
@@ -399,19 +398,18 @@ void IcfModel<T>::VerifyInvariants() const {
   }
   DRAKE_DEMAND(nv == num_velocities_);
 
-  if (params().reduction.is_valid) {
-    const auto& r = params().reduction;
-    DRAKE_DEMAND(r.is_smaller == (ssize(r.unlocked_dofs) < num_velocities_));
-    DRAKE_DEMAND(ssize(r.unlocked_dofs) <= num_velocities_);
-    DRAKE_DEMAND(ssize(r.per_clique_unlocked_dofs) == num_cliques_);
-    nv = 0;
-    for (int c = 0; c < num_cliques_; ++c) {
-      const auto& unlocked = r.per_clique_unlocked_dofs[c];
-      DRAKE_DEMAND(ssize(unlocked) <= clique_size(c));
-      nv += ssize(unlocked);
-    }
-    DRAKE_DEMAND(nv == ssize(r.unlocked_dofs));
+  const auto& reduction = params().reduction;
+  DRAKE_DEMAND(reduction.is_smaller ==
+               (ssize(reduction.unlocked_dofs) < num_velocities_));
+  DRAKE_DEMAND(ssize(reduction.unlocked_dofs) <= num_velocities_);
+  DRAKE_DEMAND(ssize(reduction.per_clique_unlocked_dofs) == num_cliques_);
+  nv = 0;
+  for (int c = 0; c < num_cliques_; ++c) {
+    const auto& unlocked = reduction.per_clique_unlocked_dofs[c];
+    DRAKE_DEMAND(ssize(unlocked) <= clique_size(c));
+    nv += ssize(unlocked);
   }
+  DRAKE_DEMAND(nv == ssize(reduction.unlocked_dofs));
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -68,9 +68,6 @@ struct IcfParameters {
 
   // Parameters that are only used by ReduceInto().
   struct ReductionParameters {
-    // Specifies if the reduction parameters are fully populated for
-    // reduction.
-    bool is_valid{false};
     // Specifies if the reduction is actually smaller than the full problem.
     bool is_smaller{false};
     // Specifies DOFs that cannot be eliminated.
@@ -225,9 +222,7 @@ class IcfModel {
   const VectorX<T>& k0() const { return params().k0; }
 
   /* Returns true if the model can be reduced. */
-  bool is_reducible() const {
-    return params().reduction.is_valid && params().reduction.is_smaller;
-  }
+  bool is_reducible() const { return params().reduction.is_smaller; }
 
   /* Returns a reference to the spatial velocity Jacobian for the given body. */
   ConstJacobianView J_WB(int body) const {
@@ -399,7 +394,6 @@ class IcfModel {
 
   @pre reduced_model != nullptr
   @pre mapping != nullptr
-  @pre params().reduction.is_valid == true
   */
   void ReduceInto(IcfModel<T>* reduced_model, ReducedMapping* mapping) const;
 

--- a/multibody/contact_solvers/icf/test/icf_builder_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_builder_test.cc
@@ -414,7 +414,6 @@ GTEST_TEST(IcfBuilder, JointLockingSupport) {
     dut.UpdateModel(plant_context, 0.01, nullptr, nullptr, &model);
     EXPECT_FALSE(model.is_reducible());
     const auto& r = model.params().reduction;
-    EXPECT_TRUE(r.is_valid);
     EXPECT_FALSE(r.is_smaller);
     const std::vector<int> expected_unlocked_dofs = {0, 1};
     EXPECT_EQ(r.unlocked_dofs, expected_unlocked_dofs);
@@ -433,7 +432,6 @@ GTEST_TEST(IcfBuilder, JointLockingSupport) {
     dut.UpdateModel(plant_context, 0.01, nullptr, nullptr, &model);
     EXPECT_TRUE(model.is_reducible());
     const auto& r = model.params().reduction;
-    EXPECT_TRUE(r.is_valid);
     EXPECT_TRUE(r.is_smaller);
     const std::vector<int> expected_unlocked_dofs = {0};
     EXPECT_EQ(r.unlocked_dofs, expected_unlocked_dofs);

--- a/multibody/contact_solvers/icf/test/icf_solver_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_solver_test.cc
@@ -44,6 +44,13 @@ class IcfSolverTest : public ::testing::Test {
     params->J_WB[0] = VectorXd::LinSpaced(36, -1.0, 1.0).reshaped(6, 6);
     params->J_WB[1] = 3.4 * Matrix6<double>::Identity();
     params->body_to_clique = {0, 1};
+    auto& reduction = params->reduction;
+    reduction.unlocked_dofs = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    reduction.per_clique_unlocked_dofs =
+        {
+            {0, 1, 2, 3, 4, 5},
+            {6, 7, 8, 9, 10, 11},
+        },
     model_.ResetParameters(std::move(params));
 
     // Add a basic contact (patch) constraint with one pair and one patch.

--- a/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
@@ -194,6 +194,17 @@ void MakeModelForWeld(IcfModel<T>* model, double time_step = 0.01) {
   params->J_WB[2] = Matrix6<T>::Identity();  // Floating body.
   params->J_WB[3] = J_WB3;
 
+  // No joint locking.
+  auto& reduction = params->reduction;
+  reduction.unlocked_dofs = {0,  1,  2,  3,  4,  5,   // BR
+                             6,  7,  8,  9,  10, 11,  //
+                             12, 13, 14, 15, 16, 17};
+  reduction.per_clique_unlocked_dofs = {
+      {0, 1, 2, 3, 4, 5},
+      {6, 7, 8, 9, 10, 11},
+      {12, 13, 14, 15, 16, 17},
+  };
+
   model->ResetParameters(std::move(params));
 }
 

--- a/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.cc
+++ b/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.cc
@@ -94,6 +94,21 @@ void MakeUnconstrainedModel(IcfModel<T>* model, bool single_clique,
     params->body_to_clique = {-1, 0, 1, 2};
   }
 
+  // No joint locking.
+  auto& reduction = params->reduction;
+  reduction.unlocked_dofs = {0,  1,  2,  3,  4,  5,   // BR
+                             6,  7,  8,  9,  10, 11,  //
+                             12, 13, 14, 15, 16, 17};
+  if (single_clique) {
+    reduction.per_clique_unlocked_dofs.resize(1);
+    reduction.per_clique_unlocked_dofs[0] = reduction.unlocked_dofs;
+  } else {
+    reduction.per_clique_unlocked_dofs.resize(3);
+    reduction.per_clique_unlocked_dofs[0] = {0, 1, 2, 3, 4, 5};
+    reduction.per_clique_unlocked_dofs[1] = {6, 7, 8, 9, 10, 11};
+    reduction.per_clique_unlocked_dofs[2] = {12, 13, 14, 15, 16, 17};
+  }
+
   model->ResetParameters(std::move(params));
 }
 


### PR DESCRIPTION
A conditional validity flag (especially without `std::optional` checks) is dangerous.  As I understand it, in all practical uses the information is actually valid, so we can ditch the flag and fix the test fixtures that initialize params to also correctly initialize the dof reduction information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rpoyner-tri/drake/10)
<!-- Reviewable:end -->
